### PR TITLE
Added a loop to render helper code for all types

### DIFF
--- a/toolkit/components/uniffi-bindgen-gecko-js/src/render/js.rs
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/render/js.rs
@@ -92,7 +92,7 @@ pub impl Type {
     }
 
     fn ffi_converter(&self) -> String {
-        format!("FfiConverter{}", self.nm())
+        format!("FfiConverter{}", self.canonical_name().to_camel_case())
     }
 }
 

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Float32.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Float32.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 4;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeFloat32(value)
+    }
+    static read(dataStream) {
+        return dataStream.readFloat32()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Float64.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Float64.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 8;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeFloat64(value)
+    }
+    static read(dataStream) {
+        return dataStream.readFloat64()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Helpers.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Helpers.jsm
@@ -6,76 +6,125 @@ const CALL_INTERNAL_ERROR = 2;
 // Write/Read data to/from an ArrayBuffer
 class ArrayBufferDataStream {
     constructor(arrayBuffer) {
-      this.dataView = new DataView(arrayBuffer);
-      this.pos = 0;
+        this.dataView = new DataView(arrayBuffer);
+        this.pos = 0;
     }
-  
-    readFloat64() {
-      let rv = this.dataView.getFloat64(this.pos);
-      this.pos += 8;
-      return rv;
-    }
-  
-    writeFloat64(value) {
-      this.dataView.setFloat64(this.pos, value);
-      this.pos += 8;
-    }
-  
+
     readUint8() {
-      let rv = this.dataView.getUint8(this.pos);
-      this.pos += 1;
-      return rv;
+        let rv = this.dataView.getUint8(this.pos);
+        this.pos += 1;
+        return rv;
     }
-  
-  
+
+    readUint16() {
+        let rv = this.dataView.getUint16(this.pos);
+        this.pos += 2;
+        return rv;
+    }
+
+    readUint32() {
+        let rv = this.dataView.getUint32(this.pos);
+        this.pos += 4;
+        return rv;
+    }
+
+    readUint64() {
+        let rv = this.dataView.getUint64(this.pos);
+        this.pos += 8;
+        return rv;
+    }
+
+    readInt8() {
+        let rv = this.dataView.getInt8(this.pos);
+        this.pos += 1;
+        return rv;
+    }
+
+    readInt16() {
+        let rv = this.dataView.getInt16(this.pos);
+        this.pos += 2;
+        return rv;
+    }
+
+    readInt32() {
+        let rv = this.dataView.getInt32(this.pos);
+        this.pos += 4;
+        return rv;
+    }
+
+    readInt64() {
+        let rv = this.dataView.getInt64(this.pos);
+        this.pos += 8;
+        return rv;
+    }
+
+    readFloat32() {
+        let rv = this.dataView.getFloat32(this.pos);
+        this.pos += 4;
+        return rv;
+    }
+
+    writeFloat32(value) {
+        this.dataView.setFloat32(this.pos, value);
+        this.pos += 4;
+    }
+
+    readFloat64() {
+        let rv = this.dataView.getFloat64(this.pos);
+        this.pos += 8;
+        return rv;
+    }
+
+    writeFloat64(value) {
+        this.dataView.setFloat64(this.pos, value);
+        this.pos += 8;
+    }
+
+
+
     // TODO: write more methods
-  }
+}
 
 
-  function handleRustResult(result, liftCallback, liftErrCallback) {
+function handleRustResult(result, liftCallback, liftErrCallback) {
     switch (result.code) {
-      case CALL_SUCCESS:
-        return liftCallback(result.data);
+        case CALL_SUCCESS:
+            return liftCallback(result.data);
 
-      case CALL_ERROR:
-        throw liftErrCallback(result.data);
+        case CALL_ERROR:
+            throw liftErrCallback(result.data);
 
-      case CALL_INTERNAL_ERROR:
-        let message = result.internalErrorMessage;
-        if (message) {
-          throw new UniFFIInternalError(message);
-        } else {
-          throw new UniFFIInternalError("Unknown error");
-        }
+        case CALL_INTERNAL_ERROR:
+            let message = result.internalErrorMessage;
+            if (message) {
+                throw new UniFFIInternalError(message);
+            } else {
+                throw new UniFFIInternalError("Unknown error");
+            }
 
-      default:
-        throw new UniFFIError(`Unexpected status code: ${result.code}`);
-    }
-  }
-
-  class UniFFIError {
-    constructor(message) {
-      this.message = message;
-    }
-  }
-  class UniFFIInternalError extends UniFFIError {}
-
-class FfiConverterDouble {
-    static lift(value) {
-        return value;
-    }
-    static lower(value) {
-        return value;
-    }
-    static computeSize() {
-        return 8;
-    }
-    static write(dataStream, double) {
-        dataStream.writeFloat64(double)
-    }
-
-    static read(dataStream) {
-        return dataStream.readFloat64()
+        default:
+            throw new UniFFIError(`Unexpected status code: ${result.code}`);
     }
 }
-  
+
+class UniFFIError {
+    constructor(message) {
+        this.message = message;
+    }
+}
+
+class UniFFIInternalError extends UniFFIError {}
+
+// Base class for FFI converters that lift/lower by reading/writing to an ArrayBuffer
+class FfiConverterArrayBuffer {
+    static lift(buf) {
+        return this.read(new ArrayBufferDataStream(buf));
+    }
+
+    static lower(value) {
+        const buf = new ArrayBuffer(this.computeSize());
+        const dataStream = new ArrayBufferDataStream(buf);
+        this.write(dataStream, value);
+        return buf;
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Int16.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Int16.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 2;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeInt16(value)
+    }
+    static read(dataStream) {
+        return dataStream.readInt16()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Int32.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Int32.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 4;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeInt32(value)
+    }
+    static read(dataStream) {
+        return dataStream.readInt32()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Int64.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Int64.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 8;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeInt64(value)
+    }
+    static read(dataStream) {
+        return dataStream.readInt64()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Int8.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Int8.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 1;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeInt8(value)
+    }
+    static read(dataStream) {
+        return dataStream.readInt8()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Optional.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Optional.jsm
@@ -1,0 +1,26 @@
+class {{ ffi_converter }} extends FfiConverterArrayBuffer {
+    static read(dataStream) {
+        const code = dataStream.readUint8(0);
+        switch (code) {
+            case 0:
+                return null
+            case 1:
+                return {{ inner.ffi_converter() }}.read(dataStream)
+            default:
+                throw UniFFIError(`Unexpected code: ${code}`);
+        }
+    }
+
+    static write(dataStream, value) {
+        if (!value) {
+            dataStream.writeUint8(0);
+        }
+        dataStream.writeUint8(1);
+        {{ inner.ffi_converter() }}.write(dataStream, value)
+    }
+
+    static computeSize() {
+        return 1 + {{ inner.ffi_converter() }}.computeSize()
+    }
+}
+

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Record.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Record.jsm
@@ -1,5 +1,4 @@
-
-{%- for record in ci.iter_record_definitions() %}
+{% let record = ci.get_record_definition(name).unwrap() %}
 
 class {{ record.nm() }} {
     constructor({{ record.constructor_field_list() }}) {
@@ -9,7 +8,7 @@ class {{ record.nm() }} {
     }
 }
 
-class FfiConverter{{ record.nm() }} {
+class {{ ffi_converter }} {
     static lift(buf) {
         return this.read(new ArrayBufferDataStream(buf));
     }
@@ -42,45 +41,4 @@ class FfiConverter{{ record.nm() }} {
     }
 }
 
-class FfiConverterOptional{{ record.nm() }} {
-    static lift(buf) {
-        return this.read(new ArrayBufferDataStream(buf));
-    }
-
-    static lower(value) {
-        const buf = new ArrayBuffer(this.computeSize());
-        const dataStream = new ArrayBufferDataStream(buf);
-        this.write(dataStream, value);
-        return buf;
-    }
-
-    static read(dataStream) {
-        const code = dataStream.readUint8(0);
-        switch (code) {
-            case 0:
-                return null
-            case 1:
-                return FfiConverter{{record.nm()}}.read(dataStream);
-            default:
-                throw UniFFIError(`Unexpected code: ${code}`);
-        }
-    }
-
-    static write(dataStream, value) {
-        if (!value) {
-            dataStream.writeUint8(0);
-            return buf;
-        }
-        dataStream.writeUint8(1);
-        FfiConverter{{record.nm()}}.write(dataStream, value);
-        return buf;
-    }
-
-    static computeSize() {
-        return 1 + FfiConverter{{record.nm()}}.computeSize();
-    }
-}
-
 EXPORTED_SYMBOLS.push("{{ record.nm() }}");
-
-{%- endfor %}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Types.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Types.jsm
@@ -1,0 +1,45 @@
+{%- for type_ in ci.iter_types() %}
+{%- let ffi_converter = type_.ffi_converter() %}
+{%- match type_ %}
+
+{%- when Type::UInt8 %}
+{%- include "UInt8.jsm" %}
+
+{%- when Type::UInt16 %}
+{%- include "UInt16.jsm" %}
+
+{%- when Type::UInt32 %}
+{%- include "UInt32.jsm" %}
+
+{%- when Type::UInt64 %}
+{%- include "UInt64.jsm" %}
+
+{%- when Type::Int8 %}
+{%- include "Int8.jsm" %}
+
+{%- when Type::Int16 %}
+{%- include "Int16.jsm" %}
+
+{%- when Type::Int32 %}
+{%- include "Int32.jsm" %}
+
+{%- when Type::Int64 %}
+{%- include "Int64.jsm" %}
+
+{%- when Type::Float32 %}
+{%- include "Float32.jsm" %}
+
+{%- when Type::Float64 %}
+{%- include "Float64.jsm" %}
+
+{%- when Type::Record with (name) %}
+{%- include "Record.jsm" %}
+
+{%- when Type::Optional with (inner) %}
+{%- include "Optional.jsm" %}
+
+{%- else %}
+{# TODO implement the other types #}
+
+{%- endmatch %}
+{%- endfor %}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/UInt16.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/UInt16.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 2;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeUint16(value)
+    }
+    static read(dataStream) {
+        return dataStream.readUint16()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/UInt32.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/UInt32.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 4;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeUint32(value)
+    }
+    static read(dataStream) {
+        return dataStream.readUint32()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/UInt64.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/UInt64.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 8;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeUint64(value)
+    }
+    static read(dataStream) {
+        return dataStream.readUint64()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/UInt8.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/UInt8.jsm
@@ -1,0 +1,17 @@
+class {{ ffi_converter }} {
+    static computeSize() {
+        return 1;
+    }
+    static lift(value) {
+        return value;
+    }
+    static lower(value) {
+        return value;
+    }
+    static write(dataStream, value) {
+        dataStream.writeUint8(value)
+    }
+    static read(dataStream) {
+        return dataStream.readUint8()
+    }
+}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/wrapper.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/wrapper.jsm
@@ -8,6 +8,6 @@ var EXPORTED_SYMBOLS = [];
 {% include "Helpers.jsm" %}
 
 
-{% include "Records.jsm" %}
+{% include "Types.jsm" %}
 
 {% include "TopLevelFunctions.jsm" %}


### PR DESCRIPTION
Added a loop that iterates through all types and renders the hepler code
for this.  This pattern has a couple advantages over iterating over
definitions (e.g. `ci.iter_record_definitions()`):
  - There are a lot of types that don't have corresponding definitions:
    primitives, compounds, datetime/timeinterval, etc.  We would need to
    add methods to the `ComponentInterface` to handle those types.
  - I like that it's simple to `let ffi_converter = type_.ffi_converter()`
    at the top of the loop and use that variable in all the helper
    templates.  We could also do that for any other `TypeJsExt` method.

Implemented helper code for primitives and optionals.

Added base class for FfiConverters that lift/lower to a `ArrayBuffer`.