### PR TITLE
Adds support for Errors in JavaScript uniffi bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5700,6 +5700,7 @@ dependencies = [
 name = "uniffi-example-geometry"
 version = "0.17.0"
 dependencies = [
+ "thiserror",
  "uniffi",
  "uniffi_build",
  "uniffi_macros",

--- a/dom/chrome-webidl/GeometryScaffolding.webidl
+++ b/dom/chrome-webidl/GeometryScaffolding.webidl
@@ -4,15 +4,15 @@
 [ChromeOnly, Exposed=Window]
 namespace GeometryScaffolding {
   [Throws]
-  Promise<UniFFIRustCallResult> geometry39efGradient(ArrayBuffer ln );
+  Promise<UniFFIRustCallResult> geometry77caGradient(ArrayBuffer ln );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry39efIntersection(ArrayBuffer ln1, ArrayBuffer ln2 );
+  Promise<UniFFIRustCallResult> geometry77caIntersection(ArrayBuffer ln1, ArrayBuffer ln2 );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry39efStringRound(ArrayBuffer s );
+  Promise<UniFFIRustCallResult> geometry77caStringRound(ArrayBuffer s );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry39efStringRecordRound(ArrayBuffer p );
+  Promise<UniFFIRustCallResult> geometry77caStringRecordRound(ArrayBuffer p );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry39efArrRound(ArrayBuffer arr, unsigned long size );
+  Promise<UniFFIRustCallResult> geometry77caArrRound(ArrayBuffer arr, unsigned long size );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry39efMapRound(ArrayBuffer map, unsigned long size );
+  Promise<UniFFIRustCallResult> geometry77caMapRound(ArrayBuffer map, unsigned long size );
 };

--- a/dom/chrome-webidl/GeometryScaffolding.webidl
+++ b/dom/chrome-webidl/GeometryScaffolding.webidl
@@ -4,15 +4,15 @@
 [ChromeOnly, Exposed=Window]
 namespace GeometryScaffolding {
   [Throws]
-  Promise<UniFFIRustCallResult> geometry77caGradient(ArrayBuffer ln );
+  Promise<UniFFIRustCallResult> geometryC24cGradient(ArrayBuffer ln );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry77caIntersection(ArrayBuffer ln1, ArrayBuffer ln2 );
+  Promise<UniFFIRustCallResult> geometryC24cIntersection(ArrayBuffer ln1, ArrayBuffer ln2 );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry77caStringRound(ArrayBuffer s );
+  Promise<UniFFIRustCallResult> geometryC24cStringRound(ArrayBuffer s );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry77caStringRecordRound(ArrayBuffer p );
+  Promise<UniFFIRustCallResult> geometryC24cStringRecordRound(ArrayBuffer p );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry77caArrRound(ArrayBuffer arr, unsigned long size );
+  Promise<UniFFIRustCallResult> geometryC24cArrRound(ArrayBuffer arr, unsigned long size );
   [Throws]
-  Promise<UniFFIRustCallResult> geometry77caMapRound(ArrayBuffer map, unsigned long size );
+  Promise<UniFFIRustCallResult> geometryC24cMapRound(ArrayBuffer map, unsigned long size );
 };

--- a/toolkit/components/geometry/Cargo.toml
+++ b/toolkit/components/geometry/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 uniffi = { git = "https://github.com/bendk/uniffi-rs.git", branch="seperate-bindings-mvp" }
 uniffi_macros = { git = "https://github.com/bendk/uniffi-rs.git", branch="seperate-bindings-mvp" }
+thiserror = "1"
 
 [build-dependencies]
 uniffi_build = { git = "https://github.com/bendk/uniffi-rs.git", branch="seperate-bindings-mvp", features = [ "builtin-bindgen" ]}

--- a/toolkit/components/geometry/js/Geometry.jsm
+++ b/toolkit/components/geometry/js/Geometry.jsm
@@ -301,7 +301,32 @@ class FfiConverterTypePoint {
     }
 }
 
-EXPORTED_SYMBOLS.push("Point");class FfiConverterOptionalTypePoint extends FfiConverterArrayBuffer {
+EXPORTED_SYMBOLS.push("Point");
+
+
+
+class GeometryError extends Error {}
+EXPORTED_SYMBOLS.push("GeometryError");
+
+
+class UndefinedGradient extends GeometryError {
+    constructor(message, ...params) {
+        super(...params);
+        this.message = message;
+    }
+}
+EXPORTED_SYMBOLS.push("UndefinedGradient");
+
+class FfiConverterTypeGeometryError extends FfiConverterArrayBuffer {
+    static read(dataStream) {
+        switch (dataStream.readInt32()) {
+            case 1:
+                return new UndefinedGradient(FfiConverterString.read(dataStream));
+            default:
+                return new Error("Unknown GeometryError variant");
+        }
+    }
+}class FfiConverterOptionalTypePoint extends FfiConverterArrayBuffer {
     static read(dataStream) {
         const code = dataStream.readUint8(0);
         switch (code) {
@@ -353,7 +378,6 @@ EXPORTED_SYMBOLS.push("Point");class FfiConverterOptionalTypePoint extends FfiCo
 }
 
 
-
 class FfiConverterMapstring extends FfiConverterArrayBuffer {
     static read(dataStream) {
         const len = dataStream.readUint32();
@@ -388,54 +412,60 @@ class FfiConverterMapstring extends FfiConverterArrayBuffer {
 
 
 function gradient(ln) {
-    const liftResult = (result) => FfiConverterF64.lift(result)
-    const liftError = null; // TODO
-    const callResult = GeometryScaffolding.geometry39efGradient(FfiConverterTypeLine.lower(ln),
+    const liftResult = (result) => FfiConverterF64.lift(result);
+    const liftError = (data) => FfiConverterTypeGeometryError.lift(data); // TODO
+
+    const callResult = GeometryScaffolding.geometry77caGradient(FfiConverterTypeLine.lower(ln),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
 
 EXPORTED_SYMBOLS.push("gradient");
 function intersection(ln1,ln2) {
-    const liftResult = (result) => FfiConverterOptionalTypePoint.lift(result)
-    const liftError = null; // TODO
-    const callResult = GeometryScaffolding.geometry39efIntersection(FfiConverterTypeLine.lower(ln1),FfiConverterTypeLine.lower(ln2),
+    const liftResult = (result) => FfiConverterOptionalTypePoint.lift(result);
+    const liftError = null;
+
+    const callResult = GeometryScaffolding.geometry77caIntersection(FfiConverterTypeLine.lower(ln1),FfiConverterTypeLine.lower(ln2),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
 
 EXPORTED_SYMBOLS.push("intersection");
 function stringRound(s) {
-    const liftResult = (result) => FfiConverterString.lift(result)
-    const liftError = null; // TODO
-    const callResult = GeometryScaffolding.geometry39efStringRound(FfiConverterString.lower(s),
+    const liftResult = (result) => FfiConverterString.lift(result);
+    const liftError = null;
+
+    const callResult = GeometryScaffolding.geometry77caStringRound(FfiConverterString.lower(s),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
 
 EXPORTED_SYMBOLS.push("stringRound");
 function stringRecordRound(p) {
-    const liftResult = (result) => FfiConverterTypePoint.lift(result)
-    const liftError = null; // TODO
-    const callResult = GeometryScaffolding.geometry39efStringRecordRound(FfiConverterTypePoint.lower(p),
+    const liftResult = (result) => FfiConverterTypePoint.lift(result);
+    const liftError = null;
+
+    const callResult = GeometryScaffolding.geometry77caStringRecordRound(FfiConverterTypePoint.lower(p),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
 
 EXPORTED_SYMBOLS.push("stringRecordRound");
 function arrRound(arr,size) {
-    const liftResult = (result) => FfiConverterSequencestring.lift(result)
-    const liftError = null; // TODO
-    const callResult = GeometryScaffolding.geometry39efArrRound(FfiConverterSequencestring.lower(arr),FfiConverterU32.lower(size),
+    const liftResult = (result) => FfiConverterSequencestring.lift(result);
+    const liftError = null;
+
+    const callResult = GeometryScaffolding.geometry77caArrRound(FfiConverterSequencestring.lower(arr),FfiConverterU32.lower(size),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
 
 EXPORTED_SYMBOLS.push("arrRound");
 function mapRound(map,size) {
-    const liftResult = (result) => FfiConverterMapstring.lift(result)
-    const liftError = null; // TODO
-    const callResult = GeometryScaffolding.geometry39efMapRound(FfiConverterMapstring.lower(map),FfiConverterU32.lower(size),
+    const liftResult = (result) => FfiConverterMapstring.lift(result);
+    const liftError = null;
+
+    const callResult = GeometryScaffolding.geometry77caMapRound(FfiConverterMapstring.lower(map),FfiConverterU32.lower(size),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }

--- a/toolkit/components/geometry/js/Geometry.jsm
+++ b/toolkit/components/geometry/js/Geometry.jsm
@@ -304,12 +304,45 @@ class FfiConverterTypePoint {
 EXPORTED_SYMBOLS.push("Point");
 
 
+class ComplexGeometryError extends Error {}
+EXPORTED_SYMBOLS.push("ComplexGeometryError");
+
+
+class NoIntersection extends ComplexGeometryError {
+    
+    constructor(
+        reason,
+        code,
+        ...params
+        ) {
+            super(...params);
+            this.reason = reason;
+            this.code = code;
+        }
+}
+EXPORTED_SYMBOLS.push("NoIntersection");
+
+class FfiConverterTypeComplexGeometryError extends FfiConverterArrayBuffer {
+    static read(dataStream) {
+        switch (dataStream.readInt32()) {
+            case 1:
+                return new NoIntersection(
+                    FfiConverterString.read(dataStream),
+                    FfiConverterU32.read(dataStream)
+                    );
+            default:
+                return new Error("Unknown ComplexGeometryError variant");
+        }
+    }
+}
+
 
 class GeometryError extends Error {}
 EXPORTED_SYMBOLS.push("GeometryError");
 
 
 class UndefinedGradient extends GeometryError {
+    
     constructor(message, ...params) {
         super(...params);
         this.message = message;
@@ -325,30 +358,6 @@ class FfiConverterTypeGeometryError extends FfiConverterArrayBuffer {
             default:
                 return new Error("Unknown GeometryError variant");
         }
-    }
-}class FfiConverterOptionalTypePoint extends FfiConverterArrayBuffer {
-    static read(dataStream) {
-        const code = dataStream.readUint8(0);
-        switch (code) {
-            case 0:
-                return null
-            case 1:
-                return FfiConverterTypePoint.read(dataStream)
-            default:
-                throw UniFFIError(`Unexpected code: ${code}`);
-        }
-    }
-
-    static write(dataStream, value) {
-        if (!value) {
-            dataStream.writeUint8(0);
-        }
-        dataStream.writeUint8(1);
-        FfiConverterTypePoint.write(dataStream, value)
-    }
-
-    static computeSize() {
-        return 1 + FfiConverterTypePoint.computeSize()
     }
 }class FfiConverterSequencestring extends FfiConverterArrayBuffer {
     static read(dataStream) {
@@ -415,17 +424,17 @@ function gradient(ln) {
     const liftResult = (result) => FfiConverterF64.lift(result);
     const liftError = (data) => FfiConverterTypeGeometryError.lift(data); // TODO
 
-    const callResult = GeometryScaffolding.geometry77caGradient(FfiConverterTypeLine.lower(ln),
+    const callResult = GeometryScaffolding.geometryC24cGradient(FfiConverterTypeLine.lower(ln),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
 
 EXPORTED_SYMBOLS.push("gradient");
 function intersection(ln1,ln2) {
-    const liftResult = (result) => FfiConverterOptionalTypePoint.lift(result);
-    const liftError = null;
+    const liftResult = (result) => FfiConverterTypePoint.lift(result);
+    const liftError = (data) => FfiConverterTypeComplexGeometryError.lift(data); // TODO
 
-    const callResult = GeometryScaffolding.geometry77caIntersection(FfiConverterTypeLine.lower(ln1),FfiConverterTypeLine.lower(ln2),
+    const callResult = GeometryScaffolding.geometryC24cIntersection(FfiConverterTypeLine.lower(ln1),FfiConverterTypeLine.lower(ln2),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
@@ -435,7 +444,7 @@ function stringRound(s) {
     const liftResult = (result) => FfiConverterString.lift(result);
     const liftError = null;
 
-    const callResult = GeometryScaffolding.geometry77caStringRound(FfiConverterString.lower(s),
+    const callResult = GeometryScaffolding.geometryC24cStringRound(FfiConverterString.lower(s),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
@@ -445,7 +454,7 @@ function stringRecordRound(p) {
     const liftResult = (result) => FfiConverterTypePoint.lift(result);
     const liftError = null;
 
-    const callResult = GeometryScaffolding.geometry77caStringRecordRound(FfiConverterTypePoint.lower(p),
+    const callResult = GeometryScaffolding.geometryC24cStringRecordRound(FfiConverterTypePoint.lower(p),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
@@ -455,7 +464,7 @@ function arrRound(arr,size) {
     const liftResult = (result) => FfiConverterSequencestring.lift(result);
     const liftError = null;
 
-    const callResult = GeometryScaffolding.geometry77caArrRound(FfiConverterSequencestring.lower(arr),FfiConverterU32.lower(size),
+    const callResult = GeometryScaffolding.geometryC24cArrRound(FfiConverterSequencestring.lower(arr),FfiConverterU32.lower(size),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }
@@ -465,7 +474,7 @@ function mapRound(map,size) {
     const liftResult = (result) => FfiConverterMapstring.lift(result);
     const liftError = null;
 
-    const callResult = GeometryScaffolding.geometry77caMapRound(FfiConverterMapstring.lower(map),FfiConverterU32.lower(size),
+    const callResult = GeometryScaffolding.geometryC24cMapRound(FfiConverterMapstring.lower(map),FfiConverterU32.lower(size),
     )
     return callResult.then((result) => handleRustResult(result,  liftResult, liftError));
 }

--- a/toolkit/components/geometry/js/GeometryScaffolding.cpp
+++ b/toolkit/components/geometry/js/GeometryScaffolding.cpp
@@ -9,7 +9,7 @@
 
 namespace uniffi::geometry {
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_39ef_gradient {
+namespace geometry_77ca_gradient {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -52,7 +52,7 @@ Args PrepareArgs(const ArrayBuffer& ln, mozilla::ErrorResult& aUniFFIError) {
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_39ef_gradient(
+    result.mReturnValue = ::geometry_77ca_gradient(
          aArgs.ln.intoRustBuffer(),
          &result.mCallStatus
      );
@@ -84,7 +84,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_39ef_intersection {
+namespace geometry_77ca_intersection {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -133,7 +133,7 @@ Args PrepareArgs(const ArrayBuffer& ln1, const ArrayBuffer& ln2, mozilla::ErrorR
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_39ef_intersection(
+    result.mReturnValue = ::geometry_77ca_intersection(
          aArgs.ln1.intoRustBuffer(),
          aArgs.ln2.intoRustBuffer(),
          &result.mCallStatus
@@ -166,7 +166,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_39ef_string_round {
+namespace geometry_77ca_string_round {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -209,7 +209,7 @@ Args PrepareArgs(const ArrayBuffer& s, mozilla::ErrorResult& aUniFFIError) {
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_39ef_string_round(
+    result.mReturnValue = ::geometry_77ca_string_round(
          aArgs.s.intoRustBuffer(),
          &result.mCallStatus
      );
@@ -241,7 +241,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_39ef_string_record_round {
+namespace geometry_77ca_string_record_round {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -284,7 +284,7 @@ Args PrepareArgs(const ArrayBuffer& p, mozilla::ErrorResult& aUniFFIError) {
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_39ef_string_record_round(
+    result.mReturnValue = ::geometry_77ca_string_record_round(
          aArgs.p.intoRustBuffer(),
          &result.mCallStatus
      );
@@ -316,7 +316,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_39ef_arr_round {
+namespace geometry_77ca_arr_round {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -361,7 +361,7 @@ Args PrepareArgs(const ArrayBuffer& arr, const uint32_t& size, mozilla::ErrorRes
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_39ef_arr_round(
+    result.mReturnValue = ::geometry_77ca_arr_round(
          aArgs.arr.intoRustBuffer(),
          aArgs.size,
          &result.mCallStatus
@@ -394,7 +394,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_39ef_map_round {
+namespace geometry_77ca_map_round {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -439,7 +439,7 @@ Args PrepareArgs(const ArrayBuffer& map, const uint32_t& size, mozilla::ErrorRes
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_39ef_map_round(
+    result.mReturnValue = ::geometry_77ca_map_round(
          aArgs.map.intoRustBuffer(),
          aArgs.size,
          &result.mCallStatus
@@ -475,7 +475,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 
 namespace mozilla::dom {
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry39efGradient(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::Geometry77caGradient(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -487,19 +487,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efGradient(const Global
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_39ef_gradient::PrepareArgs(ln, aUniFFIError);
+    auto uniFFIArgs = geometry_77ca_gradient::PrepareArgs(ln, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_39ef_gradient::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_77ca_gradient::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry39efGradient",
+                "GeometryScaffolding::Geometry77caGradient",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_39ef_gradient::Invoke(args);
+                auto result = geometry_77ca_gradient::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -511,14 +511,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efGradient(const Global
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry39efGradient task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caGradient task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry39efGradient call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caGradient call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_39ef_gradient::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_77ca_gradient::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -527,7 +527,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efGradient(const Global
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry39efIntersection(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln1, const ArrayBuffer& ln2, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::Geometry77caIntersection(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln1, const ArrayBuffer& ln2, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -539,19 +539,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efIntersection(const Gl
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_39ef_intersection::PrepareArgs(ln1, ln2, aUniFFIError);
+    auto uniFFIArgs = geometry_77ca_intersection::PrepareArgs(ln1, ln2, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_39ef_intersection::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_77ca_intersection::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry39efIntersection",
+                "GeometryScaffolding::Geometry77caIntersection",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_39ef_intersection::Invoke(args);
+                auto result = geometry_77ca_intersection::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -563,14 +563,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efIntersection(const Gl
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry39efIntersection task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caIntersection task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry39efIntersection call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caIntersection call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_39ef_intersection::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_77ca_intersection::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -579,7 +579,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efIntersection(const Gl
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry39efStringRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& s, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& s, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -591,19 +591,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efStringRound(const Glo
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_39ef_string_round::PrepareArgs(s, aUniFFIError);
+    auto uniFFIArgs = geometry_77ca_string_round::PrepareArgs(s, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_39ef_string_round::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_77ca_string_round::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry39efStringRound",
+                "GeometryScaffolding::Geometry77caStringRound",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_39ef_string_round::Invoke(args);
+                auto result = geometry_77ca_string_round::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -615,14 +615,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efStringRound(const Glo
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry39efStringRound task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caStringRound task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry39efStringRound call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caStringRound call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_39ef_string_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_77ca_string_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -631,7 +631,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efStringRound(const Glo
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry39efStringRecordRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& p, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRecordRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& p, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -643,19 +643,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efStringRecordRound(con
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_39ef_string_record_round::PrepareArgs(p, aUniFFIError);
+    auto uniFFIArgs = geometry_77ca_string_record_round::PrepareArgs(p, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_39ef_string_record_round::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_77ca_string_record_round::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry39efStringRecordRound",
+                "GeometryScaffolding::Geometry77caStringRecordRound",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_39ef_string_record_round::Invoke(args);
+                auto result = geometry_77ca_string_record_round::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -667,14 +667,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efStringRecordRound(con
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry39efStringRecordRound task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caStringRecordRound task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry39efStringRecordRound call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caStringRecordRound call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_39ef_string_record_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_77ca_string_record_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -683,7 +683,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efStringRecordRound(con
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry39efArrRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& arr, const uint32_t& size, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::Geometry77caArrRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& arr, const uint32_t& size, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -695,19 +695,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efArrRound(const Global
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_39ef_arr_round::PrepareArgs(arr, size, aUniFFIError);
+    auto uniFFIArgs = geometry_77ca_arr_round::PrepareArgs(arr, size, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_39ef_arr_round::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_77ca_arr_round::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry39efArrRound",
+                "GeometryScaffolding::Geometry77caArrRound",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_39ef_arr_round::Invoke(args);
+                auto result = geometry_77ca_arr_round::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -719,14 +719,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efArrRound(const Global
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry39efArrRound task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caArrRound task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry39efArrRound call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caArrRound call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_39ef_arr_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_77ca_arr_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -735,7 +735,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efArrRound(const Global
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry39efMapRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& map, const uint32_t& size, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::Geometry77caMapRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& map, const uint32_t& size, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -747,19 +747,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efMapRound(const Global
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_39ef_map_round::PrepareArgs(map, size, aUniFFIError);
+    auto uniFFIArgs = geometry_77ca_map_round::PrepareArgs(map, size, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_39ef_map_round::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_77ca_map_round::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry39efMapRound",
+                "GeometryScaffolding::Geometry77caMapRound",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_39ef_map_round::Invoke(args);
+                auto result = geometry_77ca_map_round::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -771,14 +771,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry39efMapRound(const Global
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry39efMapRound task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caMapRound task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry39efMapRound call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caMapRound call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_39ef_map_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_77ca_map_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );

--- a/toolkit/components/geometry/js/GeometryScaffolding.cpp
+++ b/toolkit/components/geometry/js/GeometryScaffolding.cpp
@@ -9,7 +9,7 @@
 
 namespace uniffi::geometry {
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_77ca_gradient {
+namespace geometry_c24c_gradient {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -52,7 +52,7 @@ Args PrepareArgs(const ArrayBuffer& ln, mozilla::ErrorResult& aUniFFIError) {
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_77ca_gradient(
+    result.mReturnValue = ::geometry_c24c_gradient(
          aArgs.ln.intoRustBuffer(),
          &result.mCallStatus
      );
@@ -84,7 +84,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_77ca_intersection {
+namespace geometry_c24c_intersection {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -133,7 +133,7 @@ Args PrepareArgs(const ArrayBuffer& ln1, const ArrayBuffer& ln2, mozilla::ErrorR
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_77ca_intersection(
+    result.mReturnValue = ::geometry_c24c_intersection(
          aArgs.ln1.intoRustBuffer(),
          aArgs.ln2.intoRustBuffer(),
          &result.mCallStatus
@@ -166,7 +166,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_77ca_string_round {
+namespace geometry_c24c_string_round {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -209,7 +209,7 @@ Args PrepareArgs(const ArrayBuffer& s, mozilla::ErrorResult& aUniFFIError) {
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_77ca_string_round(
+    result.mReturnValue = ::geometry_c24c_string_round(
          aArgs.s.intoRustBuffer(),
          &result.mCallStatus
      );
@@ -241,7 +241,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_77ca_string_record_round {
+namespace geometry_c24c_string_record_round {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -284,7 +284,7 @@ Args PrepareArgs(const ArrayBuffer& p, mozilla::ErrorResult& aUniFFIError) {
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_77ca_string_record_round(
+    result.mReturnValue = ::geometry_c24c_string_record_round(
          aArgs.p.intoRustBuffer(),
          &result.mCallStatus
      );
@@ -316,7 +316,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_77ca_arr_round {
+namespace geometry_c24c_arr_round {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -361,7 +361,7 @@ Args PrepareArgs(const ArrayBuffer& arr, const uint32_t& size, mozilla::ErrorRes
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_77ca_arr_round(
+    result.mReturnValue = ::geometry_c24c_arr_round(
          aArgs.arr.intoRustBuffer(),
          aArgs.size,
          &result.mCallStatus
@@ -394,7 +394,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 }
 }
 // For each Rust scaffolding function, define types and functions for calling it
-namespace geometry_77ca_map_round {
+namespace geometry_c24c_map_round {
 using namespace mozilla::dom;
 // Arguments to pass to the scaffolding function
 //
@@ -439,7 +439,7 @@ Args PrepareArgs(const ArrayBuffer& map, const uint32_t& size, mozilla::ErrorRes
 // For async calls this should be called in the worker thread
 Result Invoke(Args& aArgs) {
     Result result = {};
-    result.mReturnValue = ::geometry_77ca_map_round(
+    result.mReturnValue = ::geometry_c24c_map_round(
          aArgs.map.intoRustBuffer(),
          aArgs.size,
          &result.mCallStatus
@@ -475,7 +475,7 @@ void ReturnResult(JSContext* aContext, const Result& aCallResult, RootedDictiona
 
 namespace mozilla::dom {
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry77caGradient(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::GeometryC24cGradient(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -487,19 +487,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caGradient(const Global
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_77ca_gradient::PrepareArgs(ln, aUniFFIError);
+    auto uniFFIArgs = geometry_c24c_gradient::PrepareArgs(ln, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_77ca_gradient::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_c24c_gradient::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry77caGradient",
+                "GeometryScaffolding::GeometryC24cGradient",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_77ca_gradient::Invoke(args);
+                auto result = geometry_c24c_gradient::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -511,14 +511,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caGradient(const Global
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caGradient task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::GeometryC24cGradient task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caGradient call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::GeometryC24cGradient call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_77ca_gradient::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_c24c_gradient::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -527,7 +527,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caGradient(const Global
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry77caIntersection(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln1, const ArrayBuffer& ln2, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::GeometryC24cIntersection(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln1, const ArrayBuffer& ln2, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -539,19 +539,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caIntersection(const Gl
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_77ca_intersection::PrepareArgs(ln1, ln2, aUniFFIError);
+    auto uniFFIArgs = geometry_c24c_intersection::PrepareArgs(ln1, ln2, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_77ca_intersection::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_c24c_intersection::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry77caIntersection",
+                "GeometryScaffolding::GeometryC24cIntersection",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_77ca_intersection::Invoke(args);
+                auto result = geometry_c24c_intersection::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -563,14 +563,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caIntersection(const Gl
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caIntersection task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::GeometryC24cIntersection task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caIntersection call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::GeometryC24cIntersection call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_77ca_intersection::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_c24c_intersection::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -579,7 +579,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caIntersection(const Gl
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& s, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::GeometryC24cStringRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& s, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -591,19 +591,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRound(const Glo
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_77ca_string_round::PrepareArgs(s, aUniFFIError);
+    auto uniFFIArgs = geometry_c24c_string_round::PrepareArgs(s, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_77ca_string_round::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_c24c_string_round::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry77caStringRound",
+                "GeometryScaffolding::GeometryC24cStringRound",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_77ca_string_round::Invoke(args);
+                auto result = geometry_c24c_string_round::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -615,14 +615,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRound(const Glo
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caStringRound task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::GeometryC24cStringRound task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caStringRound call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::GeometryC24cStringRound call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_77ca_string_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_c24c_string_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -631,7 +631,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRound(const Glo
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRecordRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& p, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::GeometryC24cStringRecordRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& p, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -643,19 +643,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRecordRound(con
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_77ca_string_record_round::PrepareArgs(p, aUniFFIError);
+    auto uniFFIArgs = geometry_c24c_string_record_round::PrepareArgs(p, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_77ca_string_record_round::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_c24c_string_record_round::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry77caStringRecordRound",
+                "GeometryScaffolding::GeometryC24cStringRecordRound",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_77ca_string_record_round::Invoke(args);
+                auto result = geometry_c24c_string_record_round::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -667,14 +667,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRecordRound(con
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caStringRecordRound task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::GeometryC24cStringRecordRound task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caStringRecordRound call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::GeometryC24cStringRecordRound call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_77ca_string_record_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_c24c_string_record_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -683,7 +683,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caStringRecordRound(con
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry77caArrRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& arr, const uint32_t& size, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::GeometryC24cArrRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& arr, const uint32_t& size, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -695,19 +695,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caArrRound(const Global
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_77ca_arr_round::PrepareArgs(arr, size, aUniFFIError);
+    auto uniFFIArgs = geometry_c24c_arr_round::PrepareArgs(arr, size, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_77ca_arr_round::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_c24c_arr_round::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry77caArrRound",
+                "GeometryScaffolding::GeometryC24cArrRound",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_77ca_arr_round::Invoke(args);
+                auto result = geometry_c24c_arr_round::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -719,14 +719,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caArrRound(const Global
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caArrRound task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::GeometryC24cArrRound task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caArrRound call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::GeometryC24cArrRound call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_77ca_arr_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_c24c_arr_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );
@@ -735,7 +735,7 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caArrRound(const Global
     return uniFFIReturnPromise.forget();
 }
 using namespace uniffi::geometry;
-already_AddRefed<Promise> GeometryScaffolding::Geometry77caMapRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& map, const uint32_t& size, ErrorResult& aUniFFIError) {
+already_AddRefed<Promise> GeometryScaffolding::GeometryC24cMapRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& map, const uint32_t& size, ErrorResult& aUniFFIError) {
     // Note: Prefix our params and local variables with "uniffi" to avoid name
     // conflicts with the scaffolding function args
 
@@ -747,19 +747,19 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caMapRound(const Global
     }
 
     // Prepare arguments to pass to Rust
-    auto uniFFIArgs = geometry_77ca_map_round::PrepareArgs(map, size, aUniFFIError);
+    auto uniFFIArgs = geometry_c24c_map_round::PrepareArgs(map, size, aUniFFIError);
     if (aUniFFIError.Failed()) {
         return nullptr;
     }
 
     // Create a second promise that gets resolved by a background task that calls the scaffolding function
-    using UniFFITaskPromise = MozPromise<geometry_77ca_map_round::Result, nsresult, true>;
+    using UniFFITaskPromise = MozPromise<geometry_c24c_map_round::Result, nsresult, true>;
     RefPtr uniFFITaskPromise = new UniFFITaskPromise::Private(__func__);
     nsresult uniFFIDispatchResult = NS_DispatchBackgroundTask(
             NS_NewRunnableFunction(
-                "GeometryScaffolding::Geometry77caMapRound",
+                "GeometryScaffolding::GeometryC24cMapRound",
                 [args = std::move(uniFFIArgs), uniFFITaskPromise]() mutable {
-                auto result = geometry_77ca_map_round::Invoke(args);
+                auto result = geometry_c24c_map_round::Invoke(args);
                 uniFFITaskPromise->Resolve(std::move(result), __func__);
             }),
             NS_DISPATCH_EVENT_MAY_BLOCK);
@@ -771,14 +771,14 @@ already_AddRefed<Promise> GeometryScaffolding::Geometry77caMapRound(const Global
     uniFFITaskPromise->Then(GetCurrentSerialEventTarget(), __func__,
             [uniFFIXPCOMGlobal, uniFFIReturnPromise](UniFFITaskPromise::ResolveOrRejectValue&& aResult) {
             if (!aResult.IsResolve()) {
-                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::Geometry77caMapRound task dispatch failed");
+                uniFFIReturnPromise->MaybeRejectWithUnknownError("GeometryScaffolding::GeometryC24cMapRound task dispatch failed");
                 return;
             }
 
-            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::Geometry77caMapRound call resolve");
+            AutoEntryScript aes(uniFFIXPCOMGlobal, "GeometryScaffolding::GeometryC24cMapRound call resolve");
             RootedDictionary<UniFFIRustCallResult> returnValue(aes.cx());
 
-            geometry_77ca_map_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
+            geometry_c24c_map_round::ReturnResult(aes.cx(), aResult.ResolveValue(), returnValue);
             uniFFIReturnPromise->MaybeResolve(returnValue);
             }
     );

--- a/toolkit/components/geometry/js/GeometryScaffolding.h
+++ b/toolkit/components/geometry/js/GeometryScaffolding.h
@@ -12,17 +12,17 @@
 
 // Scaffolding functions from UniFFI
 extern "C" {
-double geometry_39ef_gradient(RustBuffer, RustCallStatus*);
+double geometry_77ca_gradient(RustBuffer, RustCallStatus*);
 
-RustBuffer geometry_39ef_intersection(RustBuffer, RustBuffer, RustCallStatus*);
+RustBuffer geometry_77ca_intersection(RustBuffer, RustBuffer, RustCallStatus*);
 
-RustBuffer geometry_39ef_string_round(RustBuffer, RustCallStatus*);
+RustBuffer geometry_77ca_string_round(RustBuffer, RustCallStatus*);
 
-RustBuffer geometry_39ef_string_record_round(RustBuffer, RustCallStatus*);
+RustBuffer geometry_77ca_string_record_round(RustBuffer, RustCallStatus*);
 
-RustBuffer geometry_39ef_arr_round(RustBuffer, uint32_t, RustCallStatus*);
+RustBuffer geometry_77ca_arr_round(RustBuffer, uint32_t, RustCallStatus*);
 
-RustBuffer geometry_39ef_map_round(RustBuffer, uint32_t, RustCallStatus*);
+RustBuffer geometry_77ca_map_round(RustBuffer, uint32_t, RustCallStatus*);
 
 }
 
@@ -32,12 +32,12 @@ class GlobalObject;
 
 class GeometryScaffolding {
   public:
-  static already_AddRefed<Promise> Geometry39efGradient(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry39efIntersection(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln1, const ArrayBuffer& ln2, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry39efStringRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& s, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry39efStringRecordRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& p, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry39efArrRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& arr, const uint32_t& size, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry39efMapRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& map, const uint32_t& size, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> Geometry77caGradient(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> Geometry77caIntersection(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln1, const ArrayBuffer& ln2, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> Geometry77caStringRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& s, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> Geometry77caStringRecordRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& p, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> Geometry77caArrRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& arr, const uint32_t& size, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> Geometry77caMapRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& map, const uint32_t& size, ErrorResult& aUniFFIErrorResult);
 };
 
 }  // namespace mozilla::dom

--- a/toolkit/components/geometry/js/GeometryScaffolding.h
+++ b/toolkit/components/geometry/js/GeometryScaffolding.h
@@ -12,17 +12,17 @@
 
 // Scaffolding functions from UniFFI
 extern "C" {
-double geometry_77ca_gradient(RustBuffer, RustCallStatus*);
+double geometry_c24c_gradient(RustBuffer, RustCallStatus*);
 
-RustBuffer geometry_77ca_intersection(RustBuffer, RustBuffer, RustCallStatus*);
+RustBuffer geometry_c24c_intersection(RustBuffer, RustBuffer, RustCallStatus*);
 
-RustBuffer geometry_77ca_string_round(RustBuffer, RustCallStatus*);
+RustBuffer geometry_c24c_string_round(RustBuffer, RustCallStatus*);
 
-RustBuffer geometry_77ca_string_record_round(RustBuffer, RustCallStatus*);
+RustBuffer geometry_c24c_string_record_round(RustBuffer, RustCallStatus*);
 
-RustBuffer geometry_77ca_arr_round(RustBuffer, uint32_t, RustCallStatus*);
+RustBuffer geometry_c24c_arr_round(RustBuffer, uint32_t, RustCallStatus*);
 
-RustBuffer geometry_77ca_map_round(RustBuffer, uint32_t, RustCallStatus*);
+RustBuffer geometry_c24c_map_round(RustBuffer, uint32_t, RustCallStatus*);
 
 }
 
@@ -32,12 +32,12 @@ class GlobalObject;
 
 class GeometryScaffolding {
   public:
-  static already_AddRefed<Promise> Geometry77caGradient(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry77caIntersection(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln1, const ArrayBuffer& ln2, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry77caStringRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& s, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry77caStringRecordRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& p, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry77caArrRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& arr, const uint32_t& size, ErrorResult& aUniFFIErrorResult);
-  static already_AddRefed<Promise> Geometry77caMapRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& map, const uint32_t& size, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> GeometryC24cGradient(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> GeometryC24cIntersection(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& ln1, const ArrayBuffer& ln2, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> GeometryC24cStringRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& s, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> GeometryC24cStringRecordRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& p, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> GeometryC24cArrRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& arr, const uint32_t& size, ErrorResult& aUniFFIErrorResult);
+  static already_AddRefed<Promise> GeometryC24cMapRound(const GlobalObject& aUniFFIGlobal, const ArrayBuffer& map, const uint32_t& size, ErrorResult& aUniFFIErrorResult);
 };
 
 }  // namespace mozilla::dom

--- a/toolkit/components/geometry/src/geometry.udl
+++ b/toolkit/components/geometry/src/geometry.udl
@@ -1,5 +1,7 @@
 
 namespace geometry {
+
+  [Throws=GeometryError]
   double gradient(Line ln);
   Point? intersection(Line ln1, Line ln2);
 
@@ -10,6 +12,11 @@ namespace geometry {
   sequence<string> arr_round(sequence<string> arr, u32 size);
 
   record<DOMString, string> map_round(record<DOMString, string> map, u32 size);
+};
+
+[Error]
+enum GeometryError {
+  "UndefinedGradient"
 };
 
 dictionary Point {

--- a/toolkit/components/geometry/src/geometry.udl
+++ b/toolkit/components/geometry/src/geometry.udl
@@ -3,7 +3,9 @@ namespace geometry {
 
   [Throws=GeometryError]
   double gradient(Line ln);
-  Point? intersection(Line ln1, Line ln2);
+
+  [Throws=ComplexGeometryError]
+  Point intersection(Line ln1, Line ln2);
 
   string string_round(string s);
 
@@ -17,6 +19,11 @@ namespace geometry {
 [Error]
 enum GeometryError {
   "UndefinedGradient"
+};
+
+[Error]
+interface ComplexGeometryError {
+   NoIntersection(string reason, u32 code);
 };
 
 dictionary Point {

--- a/toolkit/components/geometry/src/lib.rs
+++ b/toolkit/components/geometry/src/lib.rs
@@ -21,18 +21,27 @@ pub struct Line {
     end: Point,
 }
 
-pub fn gradient(ln: Line) -> f64 {
+#[derive(Debug, thiserror::Error)]
+pub enum GeometryError {
+    #[error("The gradient is undefined")]
+    UndefinedGradient,
+}
+
+pub fn gradient(ln: Line) -> Result<f64, GeometryError> {
     let rise = ln.end.coord_y - ln.start.coord_y;
     let run = ln.end.coord_x - ln.start.coord_x;
-    rise / run
+    if run == 0f64 {
+        return Err(GeometryError::UndefinedGradient)
+    }
+    Ok(rise/run)
 }
 
 pub fn intersection(ln1: Line, ln2: Line) -> Option<Point> {
     // TODO: yuck, should be able to take &Line as argument here
     // and have rust figure it out with a bunch of annotations...
-    let g1 = gradient(ln1.clone());
+    let g1 = gradient(ln1.clone()).unwrap();
     let z1 = ln1.start.coord_y - g1 * ln1.start.coord_x;
-    let g2 = gradient(ln2.clone());
+    let g2 = gradient(ln2.clone()).unwrap();
     let z2 = ln2.start.coord_y - g2 * ln2.start.coord_x;
     // Parallel lines do not intersect.
     if (g1 - g2).abs() < EPSILON {

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/lib.rs
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/lib.rs
@@ -52,7 +52,7 @@ impl<'a> GeckoJsBindingGenerator<'a> {
         out_dir: &Path,
     ) -> anyhow::Result<Box<dyn Write>> {
         if self.args.is_present("stdout") {
-            return Ok(Box::new(std::io::stdout()))
+            return Ok(Box::new(std::io::stdout()));
         }
 
         let out_path = if self.args.is_present("out") {
@@ -61,9 +61,10 @@ impl<'a> GeckoJsBindingGenerator<'a> {
             let filename = self.calc_filename(ci);
             out_dir.join(&filename)
         };
-        Ok(Box::new(
-            File::create(&out_path).context(format!("Failed to create {:?}", out_path.file_name()))?,
-        ))
+        Ok(Box::new(File::create(&out_path).context(format!(
+            "Failed to create {:?}",
+            out_path.file_name()
+        ))?))
     }
 
     fn calc_filename(&self, ci: &ComponentInterface) -> String {

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/render/cpp.rs
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/render/cpp.rs
@@ -1,12 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use super::shared::*;
 use askama::Template;
 use extend::ext;
 use heck::{CamelCase, MixedCase, SnakeCase};
 use uniffi_bindgen::interface::{ComponentInterface, FFIArgument, FFIFunction, FFIType};
-use super::shared::*;
 
 #[derive(Template)]
 #[template(path = "Scaffolding.cpp", escape = "none")]
@@ -50,8 +50,7 @@ pub impl FFIFunction {
     // Render our arguments as a comma-separated list, where each part is what gets passed to our
     // scaffolding function by the WebIDL code generator.
     fn input_arg_list(&self) -> String {
-        self
-            .arguments()
+        self.arguments()
             .into_iter()
             .map(|arg| format!("const {}& {}", arg.type_name(), arg.nm()))
             .collect::<Vec<String>>()

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/render/js.rs
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/render/js.rs
@@ -1,12 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use super::shared::*;
 use askama::Template;
 use extend::ext;
 use heck::{CamelCase, MixedCase};
-use super::shared::*;
-use uniffi_bindgen::interface::{ComponentInterface, FFIFunction, Record, Field, Argument, Type, Function};
+use uniffi_bindgen::interface::{
+    Argument, ComponentInterface, Error, FFIFunction, Field, Function, Record, Type,
+};
 
 #[derive(Template)]
 #[template(path = "js/wrapper.jsm", escape = "none")]
@@ -38,7 +40,11 @@ pub impl Record {
     }
 
     fn constructor_field_list(&self) -> String {
-        self.fields().iter().map(|f| f.nm()).collect::<Vec<String>>().join(",")
+        self.fields()
+            .iter()
+            .map(|f| f.nm())
+            .collect::<Vec<String>>()
+            .join(",")
     }
 }
 
@@ -80,7 +86,7 @@ pub impl Type {
             Type::Optional(inner) => format!("Optional{}", inner.nm()),
             Type::Record(name) => name.to_camel_case(),
             Type::String => "String".to_string(),
-            _ => todo!()
+            _ => todo!(),
         }
     }
 
@@ -89,7 +95,7 @@ pub impl Type {
     }
 
     fn read_datastream_fn(&self) -> String {
-       format!("{}.read", self.ffi_converter())
+        format!("{}.read", self.ffi_converter())
     }
 
     fn ffi_converter(&self) -> String {
@@ -110,11 +116,20 @@ pub impl Function {
         args
     }
 
-    fn nm(&self) -> String  {
+    fn nm(&self) -> String {
         self.name().to_mixed_case()
     }
 
     fn ffi_return_type(&self) -> String {
-        self.return_type().map(|t| t.ffi_converter()).unwrap_or("".to_string())
+        self.return_type()
+            .map(|t| t.ffi_converter())
+            .unwrap_or("".to_string())
+    }
+}
+
+#[ext(name=ErrorJSExt)]
+pub impl Error {
+    fn nm(&self) -> String {
+        self.name().to_camel_case()
     }
 }

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/render/mod.rs
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/render/mod.rs
@@ -1,22 +1,21 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::{Config, Mode};
 /// Rust code for rendering templates
 ///
 /// This module contains the `askama` templates that we use to generate our source files.  For each
 /// template, we define a set of extension traits on components from `uniffi::interface` to help
 /// render them.
-
 use askama::Template;
-use crate::{Config, Mode};
 use std::io::Write;
 use uniffi_bindgen::interface::ComponentInterface;
 
 mod cpp;
 mod js;
-mod webidl;
 mod shared;
+mod webidl;
 
 pub(crate) fn render_file(
     mode: Mode,

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/render/shared.rs
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/render/shared.rs
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /// Extension traits that are shared across multiple render targets
 use extend::ext;

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/render/webidl.rs
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/render/webidl.rs
@@ -1,11 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
- License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use super::shared::*;
 use askama::Template;
 use extend::ext;
 use heck::{CamelCase, MixedCase};
-use super::shared::*;
 use uniffi_bindgen::interface::{ComponentInterface, FFIArgument, FFIFunction, FFIType};
 
 #[derive(Template)]

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Error.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Error.jsm
@@ -2,16 +2,29 @@
 {%- let string_type = Type::String %}
 {%- let string_ffi_converter = string_type.ffi_converter() %}
 
-{% if error.is_flat() %}
-class {{ error.name().to_camel_case() }} extends Error {}
-EXPORTED_SYMBOLS.push("{{ error.name().to_camel_case() }}");
+class {{ error.nm() }} extends Error {}
+EXPORTED_SYMBOLS.push("{{ error.nm() }}");
 
 {% for variant in error.variants() %}
-class {{ variant.name().to_camel_case() }} extends {{ error.name().to_camel_case() }} {
+class {{ variant.name().to_camel_case() }} extends {{ error.nm() }} {
+    {% if error.is_flat() %}
     constructor(message, ...params) {
         super(...params);
         this.message = message;
     }
+    {%- else %}
+    constructor(
+        {% for field in variant.fields() -%}
+        {{field.nm()}},
+        {% endfor -%}
+        ...params
+        ) {
+            super(...params);
+            {%- for field in variant.fields() %}
+            this.{{field.nm()}} = {{ field.nm() }};
+            {%- endfor %}
+        }
+    {%- endif %}
 }
 EXPORTED_SYMBOLS.push("{{ variant.name().to_camel_case() }}");
 {%-endfor %}
@@ -21,11 +34,18 @@ class {{ ffi_converter }} extends FfiConverterArrayBuffer {
         switch (dataStream.readInt32()) {
             {%- for variant in error.variants() %}
             case {{ loop.index }}:
-                return new {{ variant.name().to_camel_case() }}({{ string_ffi_converter }}.read(dataStream));
+                {%- if error.is_flat() %}
+                return new {{ variant.name().to_camel_case()  }}({{ string_ffi_converter }}.read(dataStream));
+                {%- else %}
+                return new {{ variant.name().to_camel_case()  }}(
+                    {%- for field in variant.fields() %}
+                    {{ field.ffi_converter() }}.read(dataStream){%- if loop.last %}{% else %}, {%- endif %}
+                    {%- endfor %}
+                    );
+                {%- endif %}
             {%- endfor %}
             default:
-                return new Error("Unknown {{ error.name().to_camel_case() }} variant");
+                return new Error("Unknown {{ error.nm() }} variant");
         }
     }
 }
-{%- endif %}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Error.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Error.jsm
@@ -1,0 +1,31 @@
+{%- let error = ci.get_error_definition(name).unwrap() %}
+{%- let string_type = Type::String %}
+{%- let string_ffi_converter = string_type.ffi_converter() %}
+
+{% if error.is_flat() %}
+class {{ error.name().to_camel_case() }} extends Error {}
+EXPORTED_SYMBOLS.push("{{ error.name().to_camel_case() }}");
+
+{% for variant in error.variants() %}
+class {{ variant.name().to_camel_case() }} extends {{ error.name().to_camel_case() }} {
+    constructor(message, ...params) {
+        super(...params);
+        this.message = message;
+    }
+}
+EXPORTED_SYMBOLS.push("{{ variant.name().to_camel_case() }}");
+{%-endfor %}
+
+class {{ ffi_converter }} extends FfiConverterArrayBuffer {
+    static read(dataStream) {
+        switch (dataStream.readInt32()) {
+            {%- for variant in error.variants() %}
+            case {{ loop.index }}:
+                return new {{ variant.name().to_camel_case() }}({{ string_ffi_converter }}.read(dataStream));
+            {%- endfor %}
+            default:
+                return new Error("Unknown {{ error.name().to_camel_case() }} variant");
+        }
+    }
+}
+{%- endif %}

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/TopLevelFunctions.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/TopLevelFunctions.jsm
@@ -1,7 +1,13 @@
 {%- for func in ci.iter_function_definitions() %}
 function {{ func.nm() }}({{ func.arg_names() }}) {
-    const liftResult = (result) => {{ func.ffi_return_type() }}.lift(result)
-    const liftError = null; // TODO
+    const liftResult = (result) => {{ func.ffi_return_type() }}.lift(result);
+    {%- match func.throws_type() %}
+    {%- when Some with (err_type) %}
+    const liftError = (data) => {{ err_type.ffi_converter() }}.lift(data); // TODO
+    {%- else %}
+    const liftError = null;
+    {%- endmatch %}
+
     const callResult = {{ ci.scaffolding_name() }}.{{func.ffi_func().nm()}}(
         {%- for arg in func.arguments() -%}
         {{ arg.lower_fn_name() }}({{ arg.name() }}),

--- a/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Types.jsm
+++ b/toolkit/components/uniffi-bindgen-gecko-js/src/templates/js/Types.jsm
@@ -45,7 +45,10 @@
 {%- include "Sequence.jsm" %}
 
 {%- when Type::Map with (inner) %}
-{% include "Map.jsm" %}
+{%- include "Map.jsm" %}
+
+{%- when Type::Error with (name) %}
+{% include "Error.jsm" %}
 
 {%- else %}
 {# TODO implement the other types #}


### PR DESCRIPTION
Incomplete, so far implemented support for flat errors, pushing this up to get early feedback mostly on how the errors are exposed to JS developers

I exposed variants as subclasses of an error class the extends `Error`. The idea is that developers would use `instanceof` to detect the actual error variant.

I still need to implement complex errors